### PR TITLE
Override getName in ExampleWriteSupport

### DIFF
--- a/parquet-tensorflow/src/main/java/me/lyh/parquet/tensorflow/ExampleWriteSupport.java
+++ b/parquet-tensorflow/src/main/java/me/lyh/parquet/tensorflow/ExampleWriteSupport.java
@@ -34,6 +34,11 @@ public class ExampleWriteSupport extends WriteSupport<Example> {
   }
 
   @Override
+  public String getName() {
+    return "example";
+  }
+
+  @Override
   public void prepareForWrite(RecordConsumer recordConsumer) {
     this.recordConsumer = recordConsumer;
   }


### PR DESCRIPTION
hi Neville 👋 👋 👋 🎉 

Just adding this `getName` override so that the file metadata header will contain the key `writer.model.name -> example` and we can easily identify it/add discoverability tooling.