### PR TITLE
Update sbt to 2.0.6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
           java-version: '21'
           cache: 'sbt'
       - uses: sbt/setup-sbt@v1
-      - run: sbt scalafmtCheckAll scalafmtSbtCheck
+      - run: sbt "scalafmtCheckAll; scalafmtSbtCheck"
 
   test:
     runs-on: ubuntu-latest
@@ -24,7 +24,7 @@ jobs:
           java-version: '21'
           cache: 'sbt'
       - uses: sbt/setup-sbt@v1
-      - run: sbt "++${{matrix.scala}} test"
+      - run: sbt "++${{matrix.scala}}; test"
     strategy:
       matrix:
         scala:
@@ -42,5 +42,5 @@ jobs:
           cache: 'sbt'
       - uses: sbt/setup-sbt@v1
       - run: |
-          sbt coverage test coverageAggregate
+          sbt "coverage; test; coverageAggregate"
           bash <(curl -s https://codecov.io/bash)

--- a/build.sbt
+++ b/build.sbt
@@ -8,7 +8,7 @@ val scalatestVersion = "3.2.20"
 val tensorFlowVersion = "1.1.0"
 val tensorFlowProtoVersion = "1.15.0"
 
-val commonSettings = Sonatype.sonatypeSettings ++ Seq(
+val commonSettings = Seq(
   organization := "me.lyh",
   scalaVersion := "2.13.18",
   crossScalaVersions := Seq("2.12.21", "2.13.18"),
@@ -26,12 +26,11 @@ val commonSettings = Sonatype.sonatypeSettings ++ Seq(
   releasePublishArtifactsAction := PgpKeys.publishSigned.value,
   publishMavenStyle := true,
   Test / publishArtifact := false,
-  sonatypeProfileName := "me.lyh",
-  licenses := Seq("Apache 2" -> url("http://www.apache.org/licenses/LICENSE-2.0.txt")),
-  homepage := Some(url("https://github.com/nevillelyh/parquet-extra")),
+  licenses := Seq(License.Apache2),
+  homepage := Some(uri("https://github.com/nevillelyh/parquet-extra")),
   scmInfo := Some(
     ScmInfo(
-      url("https://github.com/nevillelyh/parquet-extra.git"),
+      uri("https://github.com/nevillelyh/parquet-extra.git"),
       "scm:git:git@github.com:nevillelyh/parquet-extra.git"
     )
   ),
@@ -40,7 +39,7 @@ val commonSettings = Sonatype.sonatypeSettings ++ Seq(
       id = "sinisa_lyh",
       name = "Neville Li",
       email = "neville.lyh@gmail.com",
-      url = url("https://twitter.com/sinisa_lyh")
+      url = uri("https://twitter.com/sinisa_lyh")
     )
   )
 )
@@ -59,7 +58,7 @@ lazy val root: Project = Project(
   file(".")
 ).settings(
   commonSettings ++ noPublishSettings,
-  run := parquetExamples / Compile / run
+  run := (parquetExamples / Compile / run).evaluated
 ).aggregate(
   parquetAvro,
   parquetTensorFlow,

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.12.15
+sbt.version=2.0.6

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,8 +1,11 @@
-addSbtPlugin("com.github.sbt" % "sbt-avro" % "4.0.2")
+// sbt-avro 4.0.2 is published against sbt 2.0.0-M3.
+libraryDependencies += Defaults.sbtPluginExtra(
+  "com.github.sbt" % "sbt-avro" % "4.0.2",
+  "2.0.0-M3",
+  "3"
+)
 addSbtPlugin("com.github.sbt" % "sbt-release" % "1.5.0")
 addSbtPlugin("com.github.sbt" % "sbt-pgp" % "2.3.1")
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.6.2")
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "2.4.4")
-addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.12.2")
-
 libraryDependencies += "org.apache.avro" % "avro-compiler" % "1.12.1"


### PR DESCRIPTION
## Summary

- update sbt from 1.12.15 to 2.0.6
- migrate build definitions and CI command sequencing for sbt 2
- use the sbt 2.0.0-M3 build of sbt-avro 4.0.2, which is the latest published sbt 2 artifact
- remove the obsolete sbt-sonatype plugin configuration

## Impact

The project builds and tests on the latest stable sbt 2.x release while retaining the existing Scala 2.12 and 2.13 matrix.

## Validation

- `sbt "scalafmtCheckAll; scalafmtSbtCheck"`
- `sbt "++2.12.21; test"`
- `sbt "++2.13.18; test"`
- `sbt "coverage; test; coverageAggregate"` (77.36% statement, 72.00% branch)