### PR TITLE
Update Avro to 1.12.2

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 import sbt._
 import Keys._
 
-val avroVersion = "1.12.1"
+val avroVersion = "1.12.2"
 val hadoopVersion = "3.5.0"
 val parquetVersion = "1.18.0"
 val scalatestVersion = "3.2.20"

--- a/parquet-avro/src/test/scala/me/lyh/parquet/avro/ProjectionReaderTest.scala
+++ b/parquet-avro/src/test/scala/me/lyh/parquet/avro/ProjectionReaderTest.scala
@@ -6,6 +6,7 @@ import org.apache.avro.file.{DataFileReader, DataFileWriter}
 import org.apache.avro.generic.{GenericData, GenericDatumReader, GenericRecord}
 import org.apache.avro.io.DatumReader
 import org.apache.avro.specific.SpecificDatumWriter
+import org.apache.avro.util.ClassSecurityValidator
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.{FileSystem, Path}
 import org.apache.parquet.avro.{
@@ -27,8 +28,21 @@ class ProjectionReaderTest extends AnyFlatSpec with Matchers with BeforeAndAfter
   private val tmpDir = sys.props("java.io.tmpdir")
   private val parquetPath: Path = new Path(tmpDir, "test-parquet-" + UUID.randomUUID())
   private val avroPath: Path = new Path(tmpDir, "test-avro-" + UUID.randomUUID())
+  private val originalClassSecurityValidator = ClassSecurityValidator.getGlobal()
 
   override def beforeAll(): Unit = {
+    ClassSecurityValidator.setGlobal(
+      ClassSecurityValidator.composite(
+        originalClassSecurityValidator,
+        ClassSecurityValidator
+          .builder()
+          .add(classOf[ProjectionTestRecord])
+          .add(classOf[ProjectionTestRecord1])
+          .add(classOf[ProjectionTestRecord2])
+          .build()
+      )
+    )
+
     val record = ProjectionTestRecord
       .newBuilder()
       .setField1(1)
@@ -59,8 +73,12 @@ class ProjectionReaderTest extends AnyFlatSpec with Matchers with BeforeAndAfter
   }
 
   override def afterAll(): Unit = {
-    FileSystem.get(new Configuration()).delete(parquetPath, false)
-    FileSystem.get(new Configuration()).delete(avroPath, false)
+    try {
+      FileSystem.get(new Configuration()).delete(parquetPath, false)
+      FileSystem.get(new Configuration()).delete(avroPath, false)
+    } finally {
+      ClassSecurityValidator.setGlobal(originalClassSecurityValidator)
+    }
   }
   private def readAvro(projection: Schema)(f: GenericRecord => Unit): Unit = {
     val file = new File(avroPath.toString)

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -8,4 +8,4 @@ addSbtPlugin("com.github.sbt" % "sbt-release" % "1.5.0")
 addSbtPlugin("com.github.sbt" % "sbt-pgp" % "2.3.1")
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.6.2")
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "2.4.4")
-libraryDependencies += "org.apache.avro" % "avro-compiler" % "1.12.1"
+libraryDependencies += "org.apache.avro" % "avro-compiler" % "1.12.2"


### PR DESCRIPTION
## Summary

- update `avro` and `avro-compiler` from 1.12.1 to 1.12.2
- explicitly trust the three generated projection records used by `ProjectionReaderTest`
- restore Avro's original global class-security validator after the test suite

This replaces #465.

## Root cause

Avro 1.12.2 introduces class-deserialization allow-listing. The dependency-only update in #465 caused Parquet projection reads to reject `com.spotify.scio.parquet.ProjectionTestRecord` as untrusted. The test now extends Avro's default validator with only its generated record classes instead of widening trust to the whole package or disabling validation.

The `project/build.properties` reference to `1.12.1` reported by Scala Steward is part of the sbt version `1.12.15`, not an Avro dependency.

## Validation

- `sbt "scalafmtCheckAll; scalafmtSbtCheck"`
- focused `ProjectionReaderTest` on Scala 2.12.21 and 2.13.18
- `sbt "++2.12.21; test"`
- `sbt "++2.13.18; test"`
- `sbt "coverage; test; coverageAggregate"` (77.36% statement, 72.00% branch)